### PR TITLE
Update ios template

### DIFF
--- a/lib/templates/ios/.liftoff/.liftoffrc
+++ b/lib/templates/ios/.liftoff/.liftoffrc
@@ -12,7 +12,7 @@ warnings_as_errors: false
 enable_static_analyzer: true
 indentation_level: 4
 use_tabs: false
-use_cocoapods: true
+dependency_managers: cocoapods
 strict_prompts: false
 enable_settings: false
 

--- a/lib/templates/ios/.liftoff/templates/UnitTests-Prefix.pch
+++ b/lib/templates/ios/.liftoff/templates/UnitTests-Prefix.pch
@@ -1,7 +1,7 @@
 #import "<%= project_name %>-Prefix.pch"
 
 #ifdef __OBJC__
-<% if use_cocoapods %>
+<% if dependency_managers == 'cocoapods' %>
     #define EXP_SHORTHAND
     #import <Specta/Specta.h>
     #import <Expecta/Expecta.h>

--- a/lib/templates/ios/.liftoff/templates/test_runner.sh
+++ b/lib/templates/ios/.liftoff/templates/test_runner.sh
@@ -1,13 +1,29 @@
 #!/bin/bash
 set -e
-CURR_DIR="$2";
-cd "$1";
-gunzip -c -S .xcactivitylog `ls -t | grep 'xcactivitylog' | head -n1` > output2.log;
-awk '{ gsub("\r", "\n"); print }' output2.log > unixfile.txt;
-LOG=`echo "puts /(^Test Suite '[\w-]+?\.xctest' started at .+?Test Suite '[\w-]+?\.xctest' (failed|passed).+?\.$)/m.match(File.read(\"unixfile.txt\"))" | ruby`;
-cd "$CURR_DIR"
-[[ -s "/Users/$USER/.rvm/scripts/rvm" ]] && source "/Users/$USER/.rvm/scripts/rvm"
-if [[ -z "$(which learn-xcpretty)" ]]; then
-  gem install learn-xcpretty
+SERVICE_URL='http://ironbroker.flatironschool.com'
+SERVICE_ENDPOINT='/e/flatiron_xcpretty'
+CURR_DIR="$2"
+NETRC=~/.netrc
+
+if [ -f ${NETRC} ]; then
+  if grep -q flatiron-push ${NETRC}; then
+    GITHUB_USERNAME=`grep -A1 flatiron-push ${NETRC} | grep login | awk '{print $2}'`
+    GITHUB_USER_ID=`grep -A2 flatiron-push ${NETRC} | grep password | awk '{print $2}'`
+  else
+    echo "Please run the iOS setup script before running any tests."
+    exit 1
+  fi
+else
+  echo "Please run the iOS setup script before running any tests."
+  exit 1
 fi
-echo "$LOG" | learn-xcpretty -t --report learn
+
+cd "$1"
+gunzip -c -S .xcactivitylog `ls -t | grep 'xcactivitylog' | head -n1` | awk '{ gsub("\r", "\n"); print }' > unixfile.txt
+TOTAL_COUNT=`tail -n10 unixfile.txt | grep -A1 xctest | grep Executed | awk '{print $2}'`
+FAILURE_COUNT=`tail -n10 unixfile.txt | grep -A1 xctest  | grep Executed | awk '{print $5}'`
+PASSING_COUNT=`echo "${TOTAL_COUNT} - ${FAILURE_COUNT}" | bc`
+REPO_NAME=`echo ${CURR_DIR} | awk -F'/' '{print $NF}'`
+cd ${CURR_DIR}
+
+curl -s -H "Content-Type: application/json" -X POST --data "{ \"username\": \"${GITHUB_USERNAME}\", \"github_user_id\": \"${GITHUB_USER_ID}\", \"repo_name\": \"${REPO_NAME}\", \"build\": { \"test_suite\": [{\"framework\": \"xcpretty\", \"formatted_output\": [], \"duration\": 0.0, \"build_output\": []}]}, \"total_count\": ${TOTAL_COUNT}, \"passing_count\": ${PASSING_COUNT}, \"failure_count\": ${FAILURE_COUNT}}" "${SERVICE_URL}${SERVICE_ENDPOINT}"

--- a/lib/templates/ios/.liftoffrc
+++ b/lib/templates/ios/.liftoffrc
@@ -12,7 +12,7 @@ warnings_as_errors: false
 enable_static_analyzer: true
 indentation_level: 4
 use_tabs: false
-use_cocoapods: true
+dependency_managers: cocoapods
 strict_prompts: false
 enable_settings: false
 

--- a/spec/learn_generate_spec.rb
+++ b/spec/learn_generate_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
-describe FlatironLabGenerator::TemplateMaker do
-  let(:lab_generator_object) {FlatironLabGenerator::TemplateMaker.new("fundamental-ruby","test_lab template","git_repo")}
+describe LearnGenerate::TemplateMaker do
+  let(:lab_generator_object) {LearnGenerate::TemplateMaker.new("fundamental-ruby","test_lab template")}
   describe "#git_init" do
     it "initializes a new local git repo" do
       lab_generator_object.git_init
@@ -11,71 +11,70 @@ describe FlatironLabGenerator::TemplateMaker do
 
   describe "::run" do
     let(:lab_name) {"test_lab"}
-    it "creates a lab template with expected name and returns nil" do
-      expect(FlatironLabGenerator::TemplateMaker.run("fundamental-ruby",lab_name, "git repo")).to be_nil 
-      expect(File.directory?(lab_name)).to eq(true) 
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── lib\n│   └── test_lab.rb\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n2 directories, 5 files\n")
+    
+    after(:each) do 
       FileUtils.rm_rf(lab_name)
+    end
+    
+    it "creates a lab template with expected name and returns nil" do
+      expect(LearnGenerate::TemplateMaker.run("fundamental-ruby",lab_name)).to be_nil 
+      expect(File.directory?(lab_name)).to eq(true)
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── lib\n│   └── test_lab.rb\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n2 directories, 5 files\n")
+    end
+
+    xit "creates a readme lab template" do 
+      expect(LearnGenerate::TemplateMaker.run("readme",lab_name)).to be_nil 
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── README.md\n├── LICENSE.md\n├── CONTRIBUTING.md\n│\n\n1 directory, 3 files\n")
     end
 
     it "creates a command-line lab template" do
-      expect(FlatironLabGenerator::TemplateMaker.run("command-line",lab_name, "git repo")).to be_nil 
+      expect(LearnGenerate::TemplateMaker.run("command-line",lab_name)).to be_nil 
       expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── bin\n│   └── runner.rb\n├── lib\n│   ├── environment.rb\n│   └── test_lab\n│       └── cli.rb\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n4 directories, 7 files\n")
-      FileUtils.rm_rf(lab_name)
     end 
 
     it "creates a SQL lab template" do 
-      expect(FlatironLabGenerator::TemplateMaker.run("sql",lab_name, "git repo")).to be_nil 
+      expect(LearnGenerate::TemplateMaker.run("sql",lab_name)).to be_nil 
       expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── bin\n│   ├── environment.rb\n│   ├── run.rb\n│   └── sql_runner.rb\n├── lib\n│   └── sample.sql\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n3 directories, 8 files\n")
-      FileUtils.rm_rf(lab_name)
     end
 
     it "creates an activerecord lab template" do
-      expect(FlatironLabGenerator::TemplateMaker.run("activerecord",lab_name, "git repo")).to be_nil 
+      expect(LearnGenerate::TemplateMaker.run("activerecord",lab_name)).to be_nil 
       expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── Rakefile\n├── app\n│   └── models\n│       └── sample-class.rb\n├── config\n│   └── environment.rb\n├── db\n│   └── migrations\n├── lib\n│   └── support\n│       ├── connection_adapter.rb\n│       └── db_registry.rb\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n8 directories, 9 files\n")
-      FileUtils.rm_rf(lab_name)
     end
 
     it "creates a rake lab template" do
-      expect(FlatironLabGenerator::TemplateMaker.run("rake",lab_name, "git repo")).to be_nil 
+      expect(LearnGenerate::TemplateMaker.run("rake",lab_name)).to be_nil 
       expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── Rakefile\n├── bin\n│   └── console\n├── config\n│   └── environment.rb\n├── lib\n│   └── test_lab.rb\n└── spec\n    ├── rakefile_spec.rb\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n4 directories, 9 files\n")
-      FileUtils.rm_rf(lab_name)
     end
 
     it "creates a rack lab template" do
-      expect(FlatironLabGenerator::TemplateMaker.run("rack",lab_name, "git repo")).to be_nil 
+      expect(LearnGenerate::TemplateMaker.run("rack",lab_name)).to be_nil 
       expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── app\n│   ├── application.rb\n│   └── controllers\n│       └── erb_maker.rb\n├── config\n│   └── environment.rb\n├── config.ru\n├── lib\n│   └── templates\n│       └── my_cool_response.html.erb\n└── spec\n    ├── controllers\n    │   └── 01_server_port_spec.rb\n    ├── spec_helper.rb\n    ├── support\n    │   └── an_ok_request.rb\n    └── test_lab_spec.rb\n\n8 directories, 11 files\n")
-      FileUtils.rm_rf(lab_name)
     end
 
     it "creates a sinatra-classic lab template" do
-      expect(FlatironLabGenerator::TemplateMaker.run("sinatra-classic",lab_name, "git repo")).to be_nil 
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── Rakefile\n├── app.rb\n├── config\n│   └── environment.rb\n├── config.ru\n├── models\n├── public\n│   ├── images\n│   ├── javascripts\n│   └── stylesheets\n├── spec\n│   ├── spec_helper.rb\n│   └── test_lab_spec.rb\n└── views\n\n8 directories, 8 files\n")
-      FileUtils.rm_rf(lab_name)
+      expect(LearnGenerate::TemplateMaker.run("sinatra-classic",lab_name)).to be_nil 
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── LICENSE.md\n├── README.md\n├── Rakefile\n├── app.rb\n├── config\n│   └── environment.rb\n├── config.ru\n├── models\n├── public\n│   ├── images\n│   ├── javascripts\n│   └── stylesheets\n├── spec\n│   ├── spec_helper.rb\n│   └── test_lab_spec.rb\n└── views\n\n8 directories, 9 files\n")
     end
 
     it "creates a sinatra-mvc lab template" do
-      expect(FlatironLabGenerator::TemplateMaker.run("sinatra-mvc",lab_name, "git repo")).to be_nil 
+      expect(LearnGenerate::TemplateMaker.run("sinatra-mvc",lab_name)).to be_nil 
       expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── Rakefile\n├── app\n│   ├── controllers\n│   │   └── application_controller.rb\n│   ├── models\n│   └── views\n│       └── layout.erb\n├── config\n│   └── environment.rb\n├── config.ru\n├── db\n│   ├── migrate\n│   └── seeds.rb\n├── public\n│   └── stylesheets\n└── spec\n    ├── controllers\n    ├── features\n    ├── models\n    └── spec_helper.rb\n\n13 directories, 9 files\n")
-      FileUtils.rm_rf(lab_name)
     end
 
     it "creates a js lab template" do
-      expect(FlatironLabGenerator::TemplateMaker.run("js",lab_name, "git repo")).to be_nil 
+      expect(LearnGenerate::TemplateMaker.run("js",lab_name)).to be_nil 
       expect(`tree #{lab_name}`).to eq("test_lab\n├── README.md\n├── css\n├── images\n├── index.html\n├── js\n│   ├── jquery-1.8.3.min.js\n│   └── test_lab.js\n├── requires.yml\n└── spec\n\n4 directories, 5 files\n" )
-      FileUtils.rm_rf(lab_name)
     end
 
     it "creates a front-end template" do
-      expect(FlatironLabGenerator::TemplateMaker.run("front-end",lab_name, "git repo")).to be_nil 
+      expect(LearnGenerate::TemplateMaker.run("front-end",lab_name)).to be_nil 
       expect(`tree #{lab_name}`).to eq("test_lab\n├── README.md\n├── css\n│   └── style.css\n├── images\n└── index.html\n\n2 directories, 3 files\n")
-      FileUtils.rm_rf(lab_name)
     end
 
     it "creates a kids template" do 
-      expect(FlatironLabGenerator::TemplateMaker.run("kids",lab_name, "git repo")).to be_nil 
+      expect(LearnGenerate::TemplateMaker.run("kids",lab_name)).to be_nil 
       expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── lib\n│   └── test_lab.rb\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n2 directories, 5 files\n")
-      FileUtils.rm_rf(lab_name)
     end
   end
 end

--- a/spec/learn_generate_spec.rb
+++ b/spec/learn_generate_spec.rb
@@ -11,70 +11,70 @@ describe LearnGenerate::TemplateMaker do
 
   describe "::run" do
     let(:lab_name) {"test_lab"}
-    
-    after(:each) do 
+
+    after(:each) do
       FileUtils.rm_rf(lab_name)
     end
-    
+
     it "creates a lab template with expected name and returns nil" do
-      expect(LearnGenerate::TemplateMaker.run("fundamental-ruby",lab_name)).to be_nil 
+      expect(LearnGenerate::TemplateMaker.run("fundamental-ruby",lab_name)).to be_nil
       expect(File.directory?(lab_name)).to eq(true)
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── lib\n│   └── test_lab.rb\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n2 directories, 5 files\n")
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── CONTRIBUTING.md\n├── Gemfile\n├── LICENSE.md\n├── README.md\n├── lib\n│   └── test_lab.rb\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n2 directories, 7 files\n")
     end
 
-    xit "creates a readme lab template" do 
-      expect(LearnGenerate::TemplateMaker.run("readme",lab_name)).to be_nil 
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── README.md\n├── LICENSE.md\n├── CONTRIBUTING.md\n│\n\n1 directory, 3 files\n")
+    it "creates a readme lab template" do
+      expect(LearnGenerate::TemplateMaker.run("readme",lab_name)).to be_nil
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── CONTRIBUTING.md\n├── LICENSE.md\n└── README.md\n\n0 directories, 3 files\n")
     end
 
     it "creates a command-line lab template" do
-      expect(LearnGenerate::TemplateMaker.run("command-line",lab_name)).to be_nil 
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── bin\n│   └── runner.rb\n├── lib\n│   ├── environment.rb\n│   └── test_lab\n│       └── cli.rb\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n4 directories, 7 files\n")
-    end 
+      expect(LearnGenerate::TemplateMaker.run("command-line",lab_name)).to be_nil
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── CONTRIBUTING.md\n├── Gemfile\n├── LICENSE.md\n├── README.md\n├── bin\n│   └── runner.rb\n├── lib\n│   ├── environment.rb\n│   └── test_lab\n│       └── cli.rb\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n4 directories, 9 files\n")
+    end
 
-    it "creates a SQL lab template" do 
-      expect(LearnGenerate::TemplateMaker.run("sql",lab_name)).to be_nil 
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── bin\n│   ├── environment.rb\n│   ├── run.rb\n│   └── sql_runner.rb\n├── lib\n│   └── sample.sql\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n3 directories, 8 files\n")
+    it "creates a SQL lab template" do
+      expect(LearnGenerate::TemplateMaker.run("sql",lab_name)).to be_nil
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── CONTRIBUTING.md\n├── Gemfile\n├── LICENSE.md\n├── README.md\n├── bin\n│   ├── environment.rb\n│   ├── run.rb\n│   └── sql_runner.rb\n├── lib\n│   └── sample.sql\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n3 directories, 10 files\n")
     end
 
     it "creates an activerecord lab template" do
-      expect(LearnGenerate::TemplateMaker.run("activerecord",lab_name)).to be_nil 
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── Rakefile\n├── app\n│   └── models\n│       └── sample-class.rb\n├── config\n│   └── environment.rb\n├── db\n│   └── migrations\n├── lib\n│   └── support\n│       ├── connection_adapter.rb\n│       └── db_registry.rb\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n8 directories, 9 files\n")
+      expect(LearnGenerate::TemplateMaker.run("activerecord",lab_name)).to be_nil
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── CONTRIBUTING.md\n├── Gemfile\n├── LICENSE.md\n├── README.md\n├── Rakefile\n├── app\n│   └── models\n│       └── sample-class.rb\n├── config\n│   └── environment.rb\n├── db\n│   └── migrations\n├── lib\n│   └── support\n│       ├── connection_adapter.rb\n│       └── db_registry.rb\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n8 directories, 11 files\n")
     end
 
     it "creates a rake lab template" do
-      expect(LearnGenerate::TemplateMaker.run("rake",lab_name)).to be_nil 
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── Rakefile\n├── bin\n│   └── console\n├── config\n│   └── environment.rb\n├── lib\n│   └── test_lab.rb\n└── spec\n    ├── rakefile_spec.rb\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n4 directories, 9 files\n")
+      expect(LearnGenerate::TemplateMaker.run("rake",lab_name)).to be_nil
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── CONTRIBUTING.md\n├── Gemfile\n├── LICENSE.md\n├── README.md\n├── Rakefile\n├── bin\n│   └── console\n├── config\n│   └── environment.rb\n├── lib\n│   └── test_lab.rb\n└── spec\n    ├── rakefile_spec.rb\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n4 directories, 11 files\n")
     end
 
     it "creates a rack lab template" do
-      expect(LearnGenerate::TemplateMaker.run("rack",lab_name)).to be_nil 
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── app\n│   ├── application.rb\n│   └── controllers\n│       └── erb_maker.rb\n├── config\n│   └── environment.rb\n├── config.ru\n├── lib\n│   └── templates\n│       └── my_cool_response.html.erb\n└── spec\n    ├── controllers\n    │   └── 01_server_port_spec.rb\n    ├── spec_helper.rb\n    ├── support\n    │   └── an_ok_request.rb\n    └── test_lab_spec.rb\n\n8 directories, 11 files\n")
+      expect(LearnGenerate::TemplateMaker.run("rack",lab_name)).to be_nil
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── CONTRIBUTING.md\n├── Gemfile\n├── LICENSE.md\n├── README.md\n├── app\n│   ├── application.rb\n│   └── controllers\n│       └── erb_maker.rb\n├── config\n│   └── environment.rb\n├── config.ru\n├── lib\n│   └── templates\n│       └── my_cool_response.html.erb\n└── spec\n    ├── controllers\n    │   └── 01_server_port_spec.rb\n    ├── spec_helper.rb\n    ├── support\n    │   └── an_ok_request.rb\n    └── test_lab_spec.rb\n\n8 directories, 13 files\n")
     end
 
     it "creates a sinatra-classic lab template" do
-      expect(LearnGenerate::TemplateMaker.run("sinatra-classic",lab_name)).to be_nil 
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── LICENSE.md\n├── README.md\n├── Rakefile\n├── app.rb\n├── config\n│   └── environment.rb\n├── config.ru\n├── models\n├── public\n│   ├── images\n│   ├── javascripts\n│   └── stylesheets\n├── spec\n│   ├── spec_helper.rb\n│   └── test_lab_spec.rb\n└── views\n\n8 directories, 9 files\n")
+      expect(LearnGenerate::TemplateMaker.run("sinatra-classic",lab_name)).to be_nil
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── CONTRIBUTING.md\n├── Gemfile\n├── LICENSE.md\n├── README.md\n├── Rakefile\n├── app.rb\n├── config\n│   └── environment.rb\n├── config.ru\n├── models\n├── public\n│   ├── images\n│   ├── javascripts\n│   └── stylesheets\n├── spec\n│   ├── spec_helper.rb\n│   └── test_lab_spec.rb\n└── views\n\n8 directories, 10 files\n")
     end
 
     it "creates a sinatra-mvc lab template" do
-      expect(LearnGenerate::TemplateMaker.run("sinatra-mvc",lab_name)).to be_nil 
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── Rakefile\n├── app\n│   ├── controllers\n│   │   └── application_controller.rb\n│   ├── models\n│   └── views\n│       └── layout.erb\n├── config\n│   └── environment.rb\n├── config.ru\n├── db\n│   ├── migrate\n│   └── seeds.rb\n├── public\n│   └── stylesheets\n└── spec\n    ├── controllers\n    ├── features\n    ├── models\n    └── spec_helper.rb\n\n13 directories, 9 files\n")
+      expect(LearnGenerate::TemplateMaker.run("sinatra-mvc",lab_name)).to be_nil
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── CONTRIBUTING.md\n├── Gemfile\n├── LICENSE.md\n├── README.md\n├── Rakefile\n├── app\n│   ├── controllers\n│   │   └── application_controller.rb\n│   ├── models\n│   └── views\n│       └── layout.erb\n├── config\n│   └── environment.rb\n├── config.ru\n├── db\n│   ├── migrate\n│   └── seeds.rb\n├── public\n│   └── stylesheets\n└── spec\n    ├── controllers\n    ├── features\n    ├── models\n    └── spec_helper.rb\n\n13 directories, 11 files\n")
     end
 
     it "creates a js lab template" do
-      expect(LearnGenerate::TemplateMaker.run("js",lab_name)).to be_nil 
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── README.md\n├── css\n├── images\n├── index.html\n├── js\n│   ├── jquery-1.8.3.min.js\n│   └── test_lab.js\n├── requires.yml\n└── spec\n\n4 directories, 5 files\n" )
+      expect(LearnGenerate::TemplateMaker.run("js",lab_name)).to be_nil
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── CONTRIBUTING.md\n├── LICENSE.md\n├── README.md\n├── css\n├── images\n├── index.html\n├── js\n│   ├── jquery-1.8.3.min.js\n│   └── test_lab.js\n├── requires.yml\n└── spec\n\n4 directories, 7 files\n" )
     end
 
     it "creates a front-end template" do
-      expect(LearnGenerate::TemplateMaker.run("front-end",lab_name)).to be_nil 
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── README.md\n├── css\n│   └── style.css\n├── images\n└── index.html\n\n2 directories, 3 files\n")
+      expect(LearnGenerate::TemplateMaker.run("front-end",lab_name)).to be_nil
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── CONTRIBUTING.md\n├── LICENSE.md\n├── README.md\n├── css\n│   └── style.css\n├── images\n└── index.html\n\n2 directories, 5 files\n")
     end
 
-    it "creates a kids template" do 
-      expect(LearnGenerate::TemplateMaker.run("kids",lab_name)).to be_nil 
-      expect(`tree #{lab_name}`).to eq("test_lab\n├── Gemfile\n├── README.md\n├── lib\n│   └── test_lab.rb\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n2 directories, 5 files\n")
+    it "creates a kids template" do
+      expect(LearnGenerate::TemplateMaker.run("kids",lab_name)).to be_nil
+      expect(`tree #{lab_name}`).to eq("test_lab\n├── CONTRIBUTING.md\n├── Gemfile\n├── LICENSE.md\n├── README.md\n├── lib\n│   └── test_lab.rb\n└── spec\n    ├── spec_helper.rb\n    └── test_lab_spec.rb\n\n2 directories, 7 files\n")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
-require_relative '../config/environment'
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'learn_generate'
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
@@ -8,5 +9,5 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = 'random'
+  config.order = 'default'
 end


### PR DESCRIPTION
Updates the iOS lab templates. Adds the following changes:
1. Updates the syntax for including CocoaPods with liftoff
2. Updates the `test_runner.sh` file to remove the `learn-xcpretty` dependency. 
3. Updates the test suite to include Contributing and License files. 
